### PR TITLE
Get apartment results from multiple apartments.com searches

### DIFF
--- a/config_example.ini
+++ b/config_example.ini
@@ -2,6 +2,7 @@
 # Do not use quotes after colon
 
 # this is the URL of the apartments.com listing with whatever search criteria you have (1 bedroom, size, commute distance, sorted by preference)
+# You can provide one or more URLs in a comma-separated list
 apartmentsURL: (https://www.apartments.com/ - fill me out)
 
 # the Google Maps API URL base. See more options here: https://developers.google.com/maps/documentation/distance-matrix/

--- a/parse_apartments.py
+++ b/parse_apartments.py
@@ -117,20 +117,20 @@ def write_parsed_to_csv(page_url, map_info, writer, pscores):
         writer.writerow(row)
 
     # get the next page URL for pagination
-    next_url_to_parse = soup.find('a', class_='next')
+    next_url = soup.find('a', class_='next')
 
     # if there's only one page this will actually be none
-    if next_url_to_parse is None:
+    if next_url is None:
         return
 
     # get the actual next URL address
-    next_url_to_parse = next_url_to_parse.get('href')
+    next_url = next_url.get('href')
 
-    if next_url_to_parse is None or next_url_to_parse == '' or next_url_to_parse == 'javascript:void(0)':
+    if next_url is None or next_url == '' or next_url == 'javascript:void(0)':
         return
 
     # recurse until the last page
-    write_parsed_to_csv(next_url_to_parse, map_info, writer, pscores)
+    write_parsed_to_csv(next_url, map_info, writer, pscores)
 
 
 def parse_apartment_information(url, map_info):

--- a/parse_apartments.py
+++ b/parse_apartments.py
@@ -114,19 +114,19 @@ def write_parsed_to_csv(page_url, map_info, writer, pscores):
         writer.writerow(row)
 
     # get the next page URL for pagination
-    next_url = soup.find('a', class_='next')
+    next_pagination_url = soup.find('a', class_='next')
     # if there's only one page this will actually be none
-    if next_url is None:
+    if next_pagination_url is None:
         return
 
     # get the actual next URL address
-    next_url = next_url.get('href')
+    next_pagination_url = next_pagination_url.get('href')
 
-    if next_url is None or next_url == '' or next_url == 'javascript:void(0)':
+    if next_pagination_url is None or next_pagination_url == '' or next_pagination_url == 'javascript:void(0)':
         return
 
     # recurse until the last page
-    write_parsed_to_csv(next_url, map_info, writer, pscores)
+    write_parsed_to_csv(next_pagination_url, map_info, writer, pscores)
 
 
 def parse_apartment_information(url, map_info):

--- a/parse_apartments.py
+++ b/parse_apartments.py
@@ -50,7 +50,7 @@ def create_csv(search_urls, map_info, fname, pscores):
         # write the header
         writer.writerow(header)
 
-        # parse current entire apartment list including pagination
+        # parse current entire apartment list including pagination for all search urls
         for url in search_urls:
             print "Now getting apartments from: %s" % url
             write_parsed_to_csv(url, map_info, writer, pscores)
@@ -513,7 +513,7 @@ def main():
     conf = configparser.ConfigParser()
     conf.read('config.ini')
 
-    # get the apartments.com search URL
+    # get the apartments.com search URL(s)
     apartments_url_config = conf.get('all', 'apartmentsURL')
     urls = apartments_url_config.replace(" ", "").split(",")
 


### PR DESCRIPTION
Adding the ability to define multiple URLs in the scaper config. Thus, if someone has multiple search criteria for apartments.com (i.e. 2 bedrooms for $2,200 and 3 bedroom for $3000), they can define that for this scraper through the config. 