### PR TITLE
Commit changes to print(), fields['name'], and absolute path for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config.ini
 .DS_Store
 .vscode
+/.vs

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You also need to install
 In order to generate the CSV file:
 
 1. Rename config_example.ini to config.ini.
+	- In the parse_apartments.py file, declare the absolute path of the config.ini file in main().
 1. Search for apartments on apartments.com. Use your own criteria using the app. Copy the URL.
     - Replace the parenthesis after "apartmentsURL:" in config.ini with the copied URL.
 1. Get an API key from [Google Maps API](https://developers.google.com/maps/documentation/distance-matrix/get-api-key) (this is for calculating distances / times using Google Maps).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ You also need to install
 In order to generate the CSV file:
 
 1. Rename config_example.ini to config.ini.
-	- In the parse_apartments.py file, declare the absolute path of the config.ini file in main().
 1. Search for apartments on apartments.com. Use your own criteria using the app. Copy the URL.
     - Replace the parenthesis after "apartmentsURL:" in config.ini with the copied URL.
 1. Get an API key from [Google Maps API](https://developers.google.com/maps/documentation/distance-matrix/get-api-key) (this is for calculating distances / times using Google Maps).

--- a/parse_apartments.py
+++ b/parse_apartments.py
@@ -52,7 +52,7 @@ def create_csv(search_urls, map_info, fname, pscores):
 
         # parse current entire apartment list including pagination for all search urls
         for url in search_urls:
-            print "Now getting apartments from: %s" % url
+            print ("Now getting apartments from: %s" % url)
             write_parsed_to_csv(url, map_info, writer, pscores)
 
     finally:
@@ -95,7 +95,7 @@ def write_parsed_to_csv(page_url, map_info, writer, pscores):
         fields = parse_apartment_information(url, map_info)
 
         # make this wiki markup
-        fields['name'] = '[' + fields['name'] + '](' + url + ')'
+        fields['name'] = '[' + str(fields['name']) + '](' + url + ')'
         fields['address'] = '[' + fields['address'] + '](' + fields['map'] + ')'
 
         # fill out the CSV file
@@ -511,7 +511,9 @@ def main():
     """Read from the config file and get the Google maps info optionally"""
 
     conf = configparser.ConfigParser()
-    conf.read('config.ini')
+
+    # best to use the absolute path of the config file, prevents configparser.NoSectionError: No section: 'all'
+    conf.read('C:/whatever your path is/config.ini')
 
     # get the apartments.com search URL(s)
     apartments_url_config = conf.get('all', 'apartmentsURL')

--- a/parse_apartments.py
+++ b/parse_apartments.py
@@ -6,6 +6,7 @@ import re
 import sys
 import datetime
 import requests
+import os
 from bs4 import BeautifulSoup
 
 # Config parser was renamed in Python 3
@@ -511,9 +512,8 @@ def main():
     """Read from the config file and get the Google maps info optionally"""
 
     conf = configparser.ConfigParser()
-
-    # best to use the absolute path of the config file, prevents configparser.NoSectionError: No section: 'all'
-    conf.read('C:/whatever your path is/config.ini')
+    config_file = os.path.join(os.path.dirname(__file__), "config.ini")
+    conf.read(config_file)
 
     # get the apartments.com search URL(s)
     apartments_url_config = conf.get('all', 'apartmentsURL')


### PR DESCRIPTION
The print function was not surrounded with parenthesis. When declaring fields['name], fields['name'] is being returned as bytes, it is now being cast as string. Config.read() was not finding the config file in the current directory, best to use absolute path to prevent error.